### PR TITLE
Dev

### DIFF
--- a/src/f/fhsae.ado
+++ b/src/f/fhsae.ado
@@ -22,7 +22,6 @@
 
 cap set matastrict off
 cap prog drop fhsae
-clear mata
 program define fhsae, eclass
 	version 11.2
 	#delimit ;

--- a/src/f/fhsae.sthlp
+++ b/src/f/fhsae.sthlp
@@ -59,7 +59,7 @@
 {opt FHCV:predict(newvarname)} New variable name for predicted Fay Herriot small area estimate coefficient of variation
 
 {phang}
-{opt GAMMA:predict(newvarname)} New variable name for predicted Fay Herriot estimated Gamma
+{opt GAMMA:predict(newvarname)} New variable name for predicted Fay Herriot estimated Gamma. The eblup is the result of xb*gamma+(1-gamma)*direct
 
 {phang}
 {opt DSE:predict(newvarname)} New variable name for predicted Fay Herriot direct estimate standard error 

--- a/src/f/fhsae.sthlp
+++ b/src/f/fhsae.sthlp
@@ -59,6 +59,9 @@
 {opt FHCV:predict(newvarname)} New variable name for predicted Fay Herriot small area estimate coefficient of variation
 
 {phang}
+{opt GAMMA:predict(newvarname)} New variable name for predicted Fay Herriot estimated Gamma
+
+{phang}
 {opt DSE:predict(newvarname)} New variable name for predicted Fay Herriot direct estimate standard error 
 
 {phang}


### PR DESCRIPTION
fhsae: Add gamma prediction, remove clear mata.

This change adds the option to predict Gamma within the fhsae command using the GAMMA:predict(newvarname) option. It also removes the clear mata command within the program definition.

Changes
Added the GAMMA:predict(newvarname) option to the fhsae help file (fhsae.sthlp). This allows users to predict the Fay Herriot estimated Gamma.
Removed the clear mata command from the fhsae.ado file.
Impact
The fhsae command now allows prediction of the Gamma parameter. Users can obtain the Gamma estimate using the predict option.
Removing clear Mata may affect the program's behavior if it relies on a clean Mata environment. However, given Mata's typical usage, this is unlikely to cause issues and was likely a superfluous command. No dependencies appear to be directly affected.